### PR TITLE
Add support for `carrierwave` 1.0.x

### DIFF
--- a/lib/newrelic_carrierwave/instrumentation.rb
+++ b/lib/newrelic_carrierwave/instrumentation.rb
@@ -89,7 +89,7 @@ DependencyDetection.defer do
 
             alias :call_authenticted_url_without_newrelic_trace :authenticated_url
             alias :authenticated_url :call_authenticted_url_with_newrelic_trace
-            
+
         end
 
         ::CarrierWave::Storage::Fog.class_eval do
@@ -144,14 +144,14 @@ DependencyDetection.defer do
 
     executes do
         ::CarrierWave::Uploader::Versions::ClassMethods.class_eval do
-  
+
             def version_with_newrelic_trace(name, options = {}, &block)
                 metrics = ["Custom/CarrierWave/Version/#{name}"]
                 self.class.trace_execution_scoped(metrics) do
                     version_without_newrelic_trace(name, options, &block)
                 end
             end
-  
+
             alias :version_without_newrelic_trace :version
             alias :version :version_with_newrelic_trace
         end
@@ -255,7 +255,7 @@ DependencyDetection.defer do
                 def manipulate_with_newrelic(&block)
                   metrics = ["Custom/CarrierWave/Manipulate"]
                   self.class.trace_execution_scoped(metrics) do
-                    manipulate_without_newrelic(options, &block)
+                    manipulate_without_newrelic(&block)
                   end
                 end
 

--- a/newrelic-carrierwave.gemspec
+++ b/newrelic-carrierwave.gemspec
@@ -8,30 +8,22 @@ Gem::Specification.new do |s|
   s.name = "newrelic-carrierwave"
   s.version = NewRelicCarrierWave::VERSION
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Servando Salazar"]
   s.date = "2013-01-24"
   s.description = "Carrierwave instrumentation for Newrelic."
   s.email = ["servando@gmail.com"]
-  s.files = ["lib/newrelic-carrierwave.rb", "lib/newrelic_carrierwave/instrumentation.rb", "lib/newrelic_carrierwave/version.rb"]
+  s.files = [
+    "lib/newrelic-carrierwave.rb",
+    "lib/newrelic_carrierwave/instrumentation.rb",
+    "lib/newrelic_carrierwave/version.rb"
+  ]
   s.homepage = "http://github.com/tehprofessor/carrierwave-newrelic"
   s.require_paths = ["lib"]
   s.summary = "Carrierwave instrumentation for Newrelic."
   s.test_files = []
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 3
+  s.add_dependency "carrierwave", ">= 0.8", "< 1.1"
+  s.add_dependency "newrelic_rpm", "~> 3.0"
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<carrierwave>, ["~> 0.8"])
-      s.add_runtime_dependency(%q<newrelic_rpm>, ["~> 3.0"])
-      s.add_development_dependency(%q<rdoc>, ["~> 3.10"])
-    else
-      s.add_dependency(%q<carrierwave>, ["~> 0.8"])
-      s.add_dependency(%q<newrelic_rpm>, ["~> 3.0"])
-    end
-  else
-    s.add_dependency(%q<carrierwave>, ["~> 0.8"])
-    s.add_dependency(%q<newrelic_rpm>, ["~> 3.0"])
-  end
+  s.add_development_dependency "rdoc", "~> 3.10"
 end


### PR DESCRIPTION
This relaxes the version constraint to allow support for `carrierwave` version 1.0.x which was recently released.

This also cleans up the gemspec file for readability and current version conventions.